### PR TITLE
fix __all__ of cache.py

### DIFF
--- a/shove/cache.py
+++ b/shove/cache.py
@@ -15,7 +15,7 @@ from shove.base import Mapping, FileBase
 
 
 __all__ = (
-    'FileCache FileLRUCache MemoryCache SimpleCache MemoryLRUCache'
+    'FileCache FileLRUCache MemoryCache SimpleCache MemoryLRUCache '
     'SimpleLRUCache'
 ).split()
 


### PR DESCRIPTION
`MemoryLRUCache` and `SimpleLRUCache` get grouped together as `MemoryLRUCacheSimpleLRUCache` without the space.